### PR TITLE
Update base image to reduce app image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.18-bullseye-slim
+FROM node:20.19-alpine3.20
 
 # Set the locale
 ENV LANG=en_US.UTF-8
@@ -7,14 +7,10 @@ ENV LC_ALL=en_US.UTF-8
 ENV NODE_ENV=production
 
 # Use a cache mount for apt to speed up the process
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  openssh-client python3 g++ build-essential git locales locales-all libcap-dev nginx gettext wget && \
-  rm -rf /var/lib/apt/lists/* && \
-  yarn config set python /usr/bin/python3 && \
-  npm install -g node-gyp npm@9.3.1 cross-env@7.0.3
+RUN apk add --no-cache openssh-client python3 g++ git musl libcap-dev nginx gettext wget py3-setuptools make bash findutils && \
+    yarn config set python /usr/bin/python3 && \
+    npm install -g node-gyp npm@9.3.1 cross-env@7.0.3
+
 
 # Set up backend
 WORKDIR /usr/src/app


### PR DESCRIPTION
Fixes #<issue_number>.

## Additional Notes

This PR updates the Dockerfile's base image for `openops-app` and respective OS package installation methods.

### Why was it changed?
The Docker image size is quite huge at `~1.96 GB` and this PR has achieved **~20% reduction** by reducing the image size to `~1.56 GB`

### Change Explanation
1. The Base image is updated from `node:20.18-bullseye-slim` to `node:20.19-alpine3.20`
2. `locales locales-all` is changed to `musl` 
3. `py3-setuptools make bash findutils` were added coz they aren't a part of alpine base image (`findutils` was necessary as the `find` tool was throwing error which is a part of `link-packages-to-root.sh` script)

## Testing Checklist

Check all that apply:

I have not been able to test in depth as I am relatively new to the OpenOps but following was working fine
1. CRUD for any existing or new workflow
2. Creation of workflows from existing templates for Jira, Slack, AWS, Azure
3. All the blocks are visible in the Blocks' section 

- [ ] I tested the feature thoroughly, including edge cases

- [ ] I verified all affected areas still work as expected

- [ ] Automated tests were added/updated if necessary

- [ ] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)

If there are UI/UX changes, include at least one of the following:

- Screenshots
- Loom video
- Preview deployment link
